### PR TITLE
fix pandoc args to agree with ismayc/thesisdown and pandoc 2.x

### DIFF
--- a/R/thesis.R
+++ b/R/thesis.R
@@ -19,7 +19,7 @@ thesis_pdf <- function(toc = TRUE, toc_depth = 3, ...){
     toc_depth = toc_depth,
     highlight = "pygments",
     keep_tex = TRUE,
-    pandoc_args = "--chapters",
+    pandoc_args = "--top-level-division=chapter",
     ...)
 
   # Mostly copied from knitr::render_sweave


### PR DESCRIPTION
this fixes error when knitting to pdf with pandoc 2.x: 
--chapters has been removed. Use --top-level-division=chapter instead.
Try pandoc --help for more information.
Error: pandoc document conversion failed with error 2
Please delete thesis.Rmd after you finish debugging the error.
Execution halted